### PR TITLE
Show help when bkn.yaml is missing

### DIFF
--- a/cmd/bkn/main.go
+++ b/cmd/bkn/main.go
@@ -27,15 +27,16 @@ func main() {
 	flag.Parse()
 
 	commands, err := config.ParseYAML(configPath)
-	if err != nil {
-		fmt.Printf("Failed to parse YAML file: %s\n", err)
-		os.Exit(1)
-	}
 
 	args := flag.Args()
 	if showHelp || len(args) == 0 {
 		ui.PrintUsage(os.Stdout, commands)
 		return
+	}
+
+	if err != nil {
+		fmt.Printf("Failed to parse YAML file: %s\n", err)
+		os.Exit(1)
 	}
 
 	option := args[0]

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -15,6 +15,10 @@ const (
 )
 
 func ListCommands(w io.Writer, commands []config.Command) {
+	if len(commands) == 0 {
+		return
+	}
+
 	fmt.Fprintf(w, "%s-----\nAvailable commands:\n-----%s\n\n", Teal, Reset)
 
 	longestName := 0

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -55,6 +55,28 @@ func TestListCommands_PaddingAlignsColumns(t *testing.T) {
 	}
 }
 
+func TestListCommands_EmptyOmitsHeader(t *testing.T) {
+	var buf bytes.Buffer
+	ListCommands(&buf, nil)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for empty commands, got: %q", buf.String())
+	}
+}
+
+func TestPrintUsage_EmptyCommandsStillPrintsFlags(t *testing.T) {
+	var buf bytes.Buffer
+	PrintUsage(&buf, nil)
+	out := buf.String()
+	for _, want := range []string{"Usage:", "-h, --help", "BKN"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("usage output missing %q", want)
+		}
+	}
+	if strings.Contains(out, "Available commands") {
+		t.Errorf("did not expect 'Available commands' header with no commands; got:\n%s", out)
+	}
+}
+
 func TestPrintUsage_IncludesFlagsAndCommands(t *testing.T) {
 	var buf bytes.Buffer
 	PrintUsage(&buf, sampleCommands())


### PR DESCRIPTION
-h/--help previously failed with a YAML parse error if no config was present. Defer the parse-error exit until after the help/no-args path so users can always view usage, and skip the "Available commands" header when the command list is empty.